### PR TITLE
 feat: UTLP-1 video time controls, resizing captions, add bookmark ctrl+b hotkey

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,7 @@ export default [
                     varsIgnorePattern: '^_',
                 },
             ],
+            'no-undef': 'off',
             '@typescript-eslint/explicit-module-boundary-types': 'error',
             '@typescript-eslint/no-empty-interface': 'error',
             '@typescript-eslint/no-explicit-any': 'error',

--- a/src/components/content/Cue.tsx
+++ b/src/components/content/Cue.tsx
@@ -94,6 +94,8 @@ const Cue = (props: CueProps): JSX.Element => {
                 }
             }}
             data-cue-id={props.id}
+            data-start={props.start}
+            data-text={props.text}
         >
             <div class='text-ut-burntorange flex h-full flex-col items-center gap-1 group-hover:underline'>
                 <p class='text-ut-burntorange text-sm font-medium'>{formatTime(props.start)}</p>

--- a/src/context/BookmarkProvider.tsx
+++ b/src/context/BookmarkProvider.tsx
@@ -44,7 +44,10 @@ const BookmarkContext = createContext<BookmarkContextValue>({
  * @param props.activeCueElement the currently active cue (transcript element)
  * @returns The BookmarkProvider component.
  */
-export function BookmarkProvider(props: { children: JSX.Element, activeCueElement: Accessor<HTMLDivElement | null> }): JSX.Element {
+export function BookmarkProvider(props: {
+    children: JSX.Element;
+    activeCueElement: Accessor<HTMLDivElement | null>;
+}): JSX.Element {
     // Store all bookmarks organized by URL
     const [allBookmarks, setAllBookmarks] = createStore<BookmarksByUrl>({});
 
@@ -97,7 +100,7 @@ export function BookmarkProvider(props: { children: JSX.Element, activeCueElemen
             }
         });
         // Add event listener for making a bookmark with Ctrl + B
-        document.addEventListener('keydown', checkBookmarkHotkey)
+        document.addEventListener('keydown', checkBookmarkHotkey);
     });
 
     // Clean up event listeners when component unmounts
@@ -135,7 +138,7 @@ export function BookmarkProvider(props: { children: JSX.Element, activeCueElemen
     };
 
     /** checkBookmarkHotkey bookmarks the current caption if there is one with the Ctrl + B hotkey,
-     * and removes the bookmark instead if it already exists. Has a 0.25 second cooldown to prevent 
+     * and removes the bookmark instead if it already exists. Has a 0.25 second cooldown to prevent
      * accidental double-presses, and holding down the key will not trigger multiple events.
      * <br> pre: current caption exists, ctrl + b pressed, event is not repeat
      * <br> post: current caption is bookmarked or unbookmarked if the bookmark exists
@@ -144,22 +147,22 @@ export function BookmarkProvider(props: { children: JSX.Element, activeCueElemen
     function checkBookmarkHotkey(event: KeyboardEvent) {
         const key: string = event.key;
         // prevent repeat by avoiding if event.repeat is true, otherwise if ctrl + b then bookmark
-        if (key == "b" && event.ctrlKey && !event.repeat) {
+        if (key == 'b' && event.ctrlKey && !event.repeat) {
             if (cooldownTimer != null) {
                 // too soon since previous click, return before work done
                 return;
             } else {
-                const cooldownAmount: number = 250 // milliseconds
+                const cooldownAmount: number = 250; // milliseconds
                 cooldownTimer = setTimeout(() => {
                     cooldownTimer = null; // Reset cooldown after 0.25sec delay
                 }, cooldownAmount);
             }
-            const toBookmark: HTMLDivElement | null = props.activeCueElement()
+            const toBookmark: HTMLDivElement | null = props.activeCueElement();
             if (toBookmark) {
-                const id = toBookmark.attributes.getNamedItem("data-cue-id")?.value
-                const startString: string | undefined = toBookmark.attributes.getNamedItem("data-start")?.value
-                const start: number = startString ? parseFloat(startString) : 0
-                const text = toBookmark.attributes.getNamedItem("data-text")?.value
+                const id = toBookmark.attributes.getNamedItem('data-cue-id')?.value;
+                const startString: string | undefined = toBookmark.attributes.getNamedItem('data-start')?.value;
+                const start: number = startString ? parseFloat(startString) : 0;
+                const text = toBookmark.attributes.getNamedItem('data-text')?.value;
                 // due to solidjs Context rules, this MUST be within BookmarkProvider or descendant
                 if (id && start && text) {
                     if (!isBookmarked(id)) {
@@ -169,11 +172,15 @@ export function BookmarkProvider(props: { children: JSX.Element, activeCueElemen
                     }
                 } else {
                     // simple test to let developer know if they inadvertently removed required part
-                    console.warn('cue was modified at some point to not have all three of \
+                    console.warn(
+                        'cue was modified at some point to not have all three of \
                         id, start, and text. Add it back or figure out an alternate bookmark \
-                        method for Ctrl + B in captionsControl!')
+                        method for Ctrl + B in captionsControl!'
+                    );
                 }
-            } else { console.warn("no selected caption to bookmark"); }
+            } else {
+                console.warn('no selected caption to bookmark');
+            }
         }
     }
 

--- a/src/context/BookmarkProvider.tsx
+++ b/src/context/BookmarkProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, JSX, createEffect, onMount, onCleanup } from 'solid-js';
+import { createContext, useContext, JSX, createEffect, onMount, onCleanup, Accessor } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import { storage } from '#imports';
 
@@ -37,13 +37,15 @@ const BookmarkContext = createContext<BookmarkContextValue>({
 });
 
 /**
- * This provider manages bookmarks for the current URL.
+ * This provider manages bookmarks for the current URL, including a Ctrl + B bookmark of activeCue
  *
  * @param props - The props object.
  * @param props.children - The child components to be rendered within the provider.
+ * @param props.activeCueElement the currently active cue (transcript element)
  * @returns The BookmarkProvider component.
  */
-export function BookmarkProvider(props: { children: JSX.Element }): JSX.Element {
+export function BookmarkProvider(props: { children: JSX.Element, activeCueElement: 
+    Accessor<HTMLDivElement | null> }): JSX.Element {
     // Store all bookmarks organized by URL
     const [allBookmarks, setAllBookmarks] = createStore<BookmarksByUrl>({});
 
@@ -95,13 +97,15 @@ export function BookmarkProvider(props: { children: JSX.Element }): JSX.Element 
                 saveBookmarks();
             }
         });
+        // Add event listener for making a bookmark with Ctrl + B
+        document.addEventListener('keydown', checkBookmarkHotkey)
     });
 
     // Clean up event listeners when component unmounts
     onCleanup(() => {
         window.removeEventListener('beforeunload', saveBookmarks);
         document.removeEventListener('visibilitychange', saveBookmarks);
-
+        document.removeEventListener('keydown', checkBookmarkHotkey);
         // Final save when component unmounts
         saveBookmarks();
     });
@@ -130,6 +134,49 @@ export function BookmarkProvider(props: { children: JSX.Element }): JSX.Element 
     const isBookmarked = (id: string) => {
         return state.bookmarks.some(bookmark => bookmark.id === id);
     };
+
+    /** checkBookmarkHotkey bookmarks the current caption if there is one with the Ctrl + B hotkey,
+     * and removes the bookmark instead if it already exists. Has a 0.25 second cooldown to prevent 
+     * accidental double-presses, and holding down the key will not trigger multiple events.
+     * <br> pre: current caption exists, ctrl + b pressed, event is not repeat
+     * <br> post: current caption is bookmarked or unbookmarked if the bookmark exists
+     */
+    let cooldownTimer: NodeJS.Timeout | null = null;
+    function checkBookmarkHotkey(event: KeyboardEvent) {
+        const key: string = event.key;
+        // prevent repeat by avoiding if event.repeat is true, otherwise if ctrl + b then bookmark
+        if (key == "b" && event.ctrlKey && !event.repeat) {
+            if (cooldownTimer != null) {
+                // too soon since previous click, return before work done
+                return;
+            } else {
+                const cooldownAmount: number = 250 // milliseconds
+                cooldownTimer = setTimeout(() => {
+                    cooldownTimer = null; // Reset cooldown after 0.25sec delay
+                }, cooldownAmount);
+            }
+            const toBookmark: HTMLDivElement | null = props.activeCueElement()
+            if (toBookmark) {
+                const id = toBookmark.attributes.getNamedItem("data-cue-id")?.value
+                const startString: string | undefined = toBookmark.attributes.getNamedItem("data-start")?.value
+                const start: number = startString ? parseFloat(startString) : 0
+                const text = toBookmark.attributes.getNamedItem("data-text")?.value
+                // due to solidjs Context rules, this MUST be within BookmarkProvider or descendant
+                if (id && start && text) {
+                    if (!isBookmarked(id)) {
+                        addBookmark({ id, start, text });
+                    } else {
+                        removeBookmark(id);
+                    }
+                } else {
+                    // simple test to let developer know if they inadvertently removed required part
+                    console.warn('cue was modified at some point to not have all three of \
+                        id, start, and text. Add it back or figure out an alternate bookmark \
+                        method for Ctrl + B in captionsControl!')
+                }
+            } else { console.warn("no selected caption to bookmark"); }
+        }
+    }
 
     return (
         <BookmarkContext.Provider

--- a/src/context/BookmarkProvider.tsx
+++ b/src/context/BookmarkProvider.tsx
@@ -37,15 +37,14 @@ const BookmarkContext = createContext<BookmarkContextValue>({
 });
 
 /**
- * This provider manages bookmarks for the current URL, including a Ctrl + B bookmark of activeCue
+ * This provider manages bookmarks for the current URL, including a Ctrl + B bookmark of activeCue.
  *
  * @param props - The props object.
  * @param props.children - The child components to be rendered within the provider.
  * @param props.activeCueElement the currently active cue (transcript element)
  * @returns The BookmarkProvider component.
  */
-export function BookmarkProvider(props: { children: JSX.Element, activeCueElement: 
-    Accessor<HTMLDivElement | null> }): JSX.Element {
+export function BookmarkProvider(props: { children: JSX.Element, activeCueElement: Accessor<HTMLDivElement | null> }): JSX.Element {
     // Store all bookmarks organized by URL
     const [allBookmarks, setAllBookmarks] = createStore<BookmarksByUrl>({});
 

--- a/src/entrypoints/main.content/App.tsx
+++ b/src/entrypoints/main.content/App.tsx
@@ -62,17 +62,16 @@ const App = (props: AppProps): JSX.Element => {
     const videoTimeControl = () => {
         const video: HTMLVideoElement | null = document.querySelector('video');
         const TIME = 10;
-        video?.addEventListener('keydown', (event) => {
+        video?.addEventListener('keydown', event => {
             const key: string = event.key;
             const callback = {
-                "ArrowLeft": () => video.currentTime -= TIME,
-                "ArrowRight": () => video.currentTime += TIME,
-                " ": () => video.paused ? video.play() : video.pause()
+                ArrowLeft: () => (video.currentTime -= TIME),
+                ArrowRight: () => (video.currentTime += TIME),
+                ' ': () => (video.paused ? video.play() : video.pause()),
             }[key];
             callback?.();
-        })
-
-    }
+        });
+    };
 
     /** captionsControl finds the video element and creates two event listeners which
      * decrease and increase caption size when the - and = keys are clicked, respectively.
@@ -80,21 +79,21 @@ const App = (props: AppProps): JSX.Element => {
      * <br> post: "-"-->shrink captions, "="-->enlarge captions by native increment
      */
     const captionsControl = () => {
-        const fontPercent = document.getElementsByClassName("vjs-font-percent vjs-track-setting")[0];
+        const fontPercent = document.getElementsByClassName('vjs-font-percent vjs-track-setting')[0];
         // can't use sizeSelect for event listener because it isn't permanent, use document
-        document?.addEventListener('keydown', (event) => {
+        document?.addEventListener('keydown', event => {
             const key: string = event.key;
             // to avoid error, only change selected size and trigger event if valid operation
-            const sizeSelect = fontPercent.querySelector("select");
+            const sizeSelect = fontPercent.querySelector('select');
             if (sizeSelect) {
                 const callback = {
-                    "=": () => {
+                    '=': () => {
                         if (sizeSelect?.selectedIndex < sizeSelect?.options?.length - 1) {
                             sizeSelect.selectedIndex += 1;
                             sizeSelect.dispatchEvent(new Event('change'));
                         }
                     },
-                    "-": () => {
+                    '-': () => {
                         if (sizeSelect?.selectedIndex > 0) {
                             sizeSelect.selectedIndex -= 1;
                             sizeSelect.dispatchEvent(new Event('change'));
@@ -103,8 +102,8 @@ const App = (props: AppProps): JSX.Element => {
                 }[key];
                 callback?.();
             }
-        })
-    }
+        });
+    };
 
     const { clear } = SearchStore;
 
@@ -277,8 +276,8 @@ const App = (props: AppProps): JSX.Element => {
                 sidebarRef.style.animation = 'var(--animate-slide-in)';
             }, 100);
         }
-        videoTimeControl()
-        captionsControl()
+        videoTimeControl();
+        captionsControl();
         onCleanup(() => {
             clearInterval(scrollInterval);
             clearInterval(overlayUpdateInterval);
@@ -289,9 +288,9 @@ const App = (props: AppProps): JSX.Element => {
         //video keydown is for videoTimeControl, and document keydown is for captionControl
         const video = props.videoElement();
         if (video) {
-            video.removeEventListener('timeupdate', () => { });
-            video.removeEventListener('play', () => { });
-            video.removeEventListener('pause', () => { });
+            video.removeEventListener('timeupdate', () => {});
+            video.removeEventListener('play', () => {});
+            video.removeEventListener('pause', () => {});
             video.removeEventListener('keydown', () => {});
         }
         document.removeEventListener('keydown', () => {});

--- a/src/entrypoints/main.content/App.tsx
+++ b/src/entrypoints/main.content/App.tsx
@@ -52,6 +52,60 @@ const App = (props: AppProps): JSX.Element => {
         opacity: 0,
     });
 
+    /** videoTimeControl finds the video element and creates three event listeners  which
+     * rewind and fast forward when the left and right arrow keys are clicked, respectively, and
+     * allow pausing by pressing spacebar.
+     * <br> pre: none
+     * <br> post: leftarrowclick-->rewind TIME seconds, rightarrowclick-->fast forward TIME sec,
+     * spacebar-->video paused/played
+     */
+    const videoTimeControl = () => {
+        const video: HTMLVideoElement | null = document.querySelector('video');
+        const TIME = 10;
+        video?.addEventListener('keydown', (event) => {
+            const key: string = event.key;
+            const callback = {
+                "ArrowLeft": () => video.currentTime -= TIME,
+                "ArrowRight": () => video.currentTime += TIME,
+                " ": () => video.paused ? video.play() : video.pause()
+            }[key];
+            callback?.();
+        })
+
+    }
+
+    /** captionsControl finds the video element and creates two event listeners which
+     * decrease and increase caption size when the - and = keys are clicked, respectively.
+     * <br> pre: none
+     * <br> post: "-"-->shrink captions, "="-->enlarge captions by native increment
+     */
+    const captionsControl = () => {
+        const fontPercent = document.getElementsByClassName("vjs-font-percent vjs-track-setting")[0];
+        // can't use sizeSelect for event listener because it isn't permanent, use document
+        document?.addEventListener('keydown', (event) => {
+            const key: string = event.key;
+            // to avoid error, only change selected size and trigger event if valid operation
+            const sizeSelect = fontPercent.querySelector("select");
+            if (sizeSelect) {
+                const callback = {
+                    "=": () => {
+                        if (sizeSelect?.selectedIndex < sizeSelect?.options?.length - 1) {
+                            sizeSelect.selectedIndex += 1;
+                            sizeSelect.dispatchEvent(new Event('change'));
+                        }
+                    },
+                    "-": () => {
+                        if (sizeSelect?.selectedIndex > 0) {
+                            sizeSelect.selectedIndex -= 1;
+                            sizeSelect.dispatchEvent(new Event('change'));
+                        }
+                    },
+                }[key];
+                callback?.();
+            }
+        })
+    }
+
     const { clear } = SearchStore;
 
     let transcriptContainerRef!: HTMLDivElement;
@@ -193,7 +247,7 @@ const App = (props: AppProps): JSX.Element => {
         }
     });
 
-    // Set up auto-scrolling with interval
+    // Set up auto-scrolling with interval along with video hotkey control
     onMount(() => {
         const scrollInterval = autoScrollHandler(500);
 
@@ -223,7 +277,8 @@ const App = (props: AppProps): JSX.Element => {
                 sidebarRef.style.animation = 'var(--animate-slide-in)';
             }, 100);
         }
-
+        videoTimeControl()
+        captionsControl()
         onCleanup(() => {
             clearInterval(scrollInterval);
             clearInterval(overlayUpdateInterval);
@@ -233,10 +288,12 @@ const App = (props: AppProps): JSX.Element => {
     onCleanup(() => {
         const video = props.videoElement();
         if (video) {
-            video.removeEventListener('timeupdate', () => {});
-            video.removeEventListener('play', () => {});
-            video.removeEventListener('pause', () => {});
+            video.removeEventListener('timeupdate', () => { });
+            video.removeEventListener('play', () => { });
+            video.removeEventListener('pause', () => { });
+            video.removeEventListener('keydown', () => {});
         }
+        document.removeEventListener('keydown', () => {});
     });
 
     const handleManualScroll = () => {
@@ -328,7 +385,7 @@ const App = (props: AppProps): JSX.Element => {
 
                     <QuickActions uiContainer={props.uiContainer} setAutoScroll={setAutoScroll} vttUrl={props.vttUrl} />
 
-                    <BookmarkProvider>
+                    <BookmarkProvider activeCueElement={activeCueElement}>
                         <Transcription
                             ref={transcriptContainerRef}
                             videoElement={props.videoElement}

--- a/src/entrypoints/main.content/App.tsx
+++ b/src/entrypoints/main.content/App.tsx
@@ -286,6 +286,7 @@ const App = (props: AppProps): JSX.Element => {
     });
 
     onCleanup(() => {
+        //video keydown is for videoTimeControl, and document keydown is for captionControl
         const video = props.videoElement();
         if (video) {
             video.removeEventListener('timeupdate', () => { });


### PR DESCRIPTION
(copy of previous pull request onto feat-rewrite branch)

Added three features to enhance lectures viewing using the existing tech stack:

- press the left arrow key to go back 10 seconds, right arrow key to go forward 10 seconds, and spacebar to stop/start the video (videoTimeControl in app.tsx)
- press the "-" key to shrink captions down and "=" to enlargen captions like in other modern video viewers such as youtube (captionResizingControl in app.tsx). Both shrinking and enlargening occur in the native increments given by LecturesOnline.
- press the ctrl + b buttons to bookmark/unbookmark a caption (checkBookmarkHotkey in BookmarkProvider.tsx)
- note: turned off no-undef rule for typescript files in eslint config (see https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors for why this is recommended)