### PR TITLE
feat: UTLP-27 Barebones right-side view (preliminary) (#38)

### DIFF
--- a/src/components/content/BookmarkButton.tsx
+++ b/src/components/content/BookmarkButton.tsx
@@ -55,16 +55,16 @@ const BookmarkButton = (props: BookmarkButtonProps): JSX.Element => {
             <div class='relative group inline-flex'>
                 <button
                     onClick={handleClick}
-                    class='flex items-center justify-center w-9 h-9 rounded-md transition-colors duration-200'
+                    class='flex items-center justify-center w-7 h-7 rounded-md transition-colors duration-200'
                     classList={{
                         'bg-ut-burntorange': isBookmarked(),
                         'bg-gray-200 hover:bg-gray-300': !isBookmarked(),
                     }}
                 >
-                    <Bookmark class='w-6 h-6' color={isBookmarked() ? 'white' : 'currentColor'} />
+                    <Bookmark class='w-4 h-4' color={isBookmarked() ? 'white' : 'currentColor'} />
                 </button>
-                <span class='pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-lg text-white bg-gray-800 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-100'>
-                    {isBookmarked() ? 'Remove bookmark' : 'Bookmark this lecture'}
+                <span class='pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-1.5 py-0.5 text-xs text-white bg-gray-800 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-100'>
+                    {isBookmarked() ? 'Remove bookmark' : 'Bookmark lecture'}
                 </span>
             </div>
         </Show>

--- a/src/components/content/EditTitleButton.tsx
+++ b/src/components/content/EditTitleButton.tsx
@@ -84,15 +84,15 @@ const EditTitleButton = (props: EditTitleButtonProps): JSX.Element => {
         <div class='relative group inline-flex'>
             <button
                 onClick={() => (isEditing() ? commitSave() : startEditing())}
-                class='flex items-center justify-center w-9 h-9 rounded-md transition-colors duration-200 bg-gray-200 hover:bg-gray-300'
+                class='flex items-center justify-center w-7 h-7 rounded-md transition-colors duration-200 bg-gray-200 hover:bg-gray-300'
                 classList={{ 'bg-ut-burntorange hover:bg-ut-burntorange': isEditing() }}
             >
-                <Show when={isEditing()} fallback={<Pencil class='w-5 h-5' />}>
-                    <Check class='w-5 h-5' color='white' />
+                <Show when={isEditing()} fallback={<Pencil class='w-4 h-4' />}>
+                    <Check class='w-4 h-4' color='white' />
                 </Show>
             </button>
-            <span class='pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-lg text-white bg-gray-800 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-100'>
-                {isEditing() ? 'Save (Enter) · Cancel (Esc)' : 'Edit lecture title'}
+            <span class='pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-1.5 py-0.5 text-xs text-white bg-gray-800 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-100'>
+                {isEditing() ? 'Save (Enter) · Cancel (Esc)' : 'Edit title'}
             </span>
         </div>
     );

--- a/src/entrypoints/episodeList.content/gridView.ts
+++ b/src/entrypoints/episodeList.content/gridView.ts
@@ -1,0 +1,296 @@
+export const VIEW_MODE_KEY = 'utlp-view-mode';
+
+let originalColumns: HTMLElement[] = [];
+
+/**
+ * Gets the current view mode from localStorage
+ *
+ * @returns {'list' | 'grid'} The current view mode, defaulting to 'list'
+ */
+export function getCurrentMode(): 'list' | 'grid' {
+    return (localStorage.getItem(VIEW_MODE_KEY) ?? 'list') as 'list' | 'grid';
+}
+
+/**
+ * Records the original column wrappers that contain episode elements,so the page's original layout can be restored when switching modes.
+ */
+export function saveOriginalPositions(): void {
+    const episodes = [...document.querySelectorAll<HTMLElement>('div.episode')];
+
+    originalColumns = [...new Set(episodes.map(ep => ep.parentElement).filter(Boolean))] as HTMLElement[];
+}
+
+/**
+ * Applies the specified view mode to the episode cards.
+ *
+ * @param {'list' | 'grid'} mode - The view mode to apply, either 'list' or 'grid'.
+ */
+export function applyViewMode(mode: 'list' | 'grid'): void {
+    const currentMode = document.body.dataset.utlpViewMode;
+    if (currentMode === mode) return;
+    document.body.dataset.utlpViewMode = mode;
+
+    const episodes = [...document.querySelectorAll<HTMLElement>('div.episode')];
+    const container = originalColumns[0]?.parentElement as HTMLElement | null;
+    if (!container) return;
+
+    if (mode === 'grid') {
+        episodes.forEach(ep => container.appendChild(ep));
+        originalColumns.forEach(col => {
+            col.style.display = 'none';
+        });
+
+        Object.assign(container.style, {
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+            gap: '16px',
+            padding: '4px 0',
+            alignItems: 'start',
+        });
+    } else {
+        episodes.forEach(ep => container.appendChild(ep));
+
+        originalColumns.forEach(col => {
+            col.style.display = 'contents';
+        });
+
+        Object.assign(container.style, {
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(450px, 1fr))',
+            gap: '4px 16px',
+        });
+    }
+
+    episodes.forEach(ep => styleEpisodeCard(ep, mode));
+}
+
+/**
+ * Styles a single episode element according to the given view mode
+ *
+ * @param episode - The episode element to style.
+ * @param {'list' | 'grid'} mode - The view mode to style the episode for.
+ */
+export function styleEpisodeCard(episode: HTMLElement, mode: 'list' | 'grid'): void {
+    episode.dataset.utlpViewMode = mode;
+    const link = episode.querySelector<HTMLAnchorElement>('a');
+    const titleEl = episode.querySelector<HTMLElement>('span.episode_title');
+
+    if (mode === 'grid') {
+        applyGridCard(episode, link, titleEl);
+    } else {
+        applyListCard(episode, link, titleEl);
+    }
+}
+
+function applyGridCard(episode: HTMLElement, link: HTMLAnchorElement | null, titleEl: HTMLElement | null) {
+    Object.assign(episode.style, {
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'transparent',
+        border: 'none',
+        boxShadow: 'none',
+        borderRadius: '0',
+        overflow: 'visible',
+        position: 'relative',
+        cursor: 'pointer',
+        transition: 'box-shadow 0.15s',
+        alignItems: 'stretch',
+        gap: '8px',
+        padding: '0',
+    });
+
+    episode.removeEventListener('mouseenter', onHoverIn);
+    episode.removeEventListener('mouseleave', onHoverOut);
+    episode.addEventListener('mouseenter', onHoverIn);
+    episode.addEventListener('mouseleave', onHoverOut);
+
+    let thumb = episode.querySelector<HTMLElement>('[data-utlp-thumb]');
+    if (!thumb) {
+        thumb = buildThumbnail();
+        episode.insertBefore(thumb, episode.firstChild);
+        thumb.style.position = 'relative';
+    }
+    thumb.style.display = 'block';
+
+    thumb.addEventListener('click', e => {
+        e.stopPropagation();
+
+        const link = episode.querySelector<HTMLAnchorElement>('a');
+        if (link?.href) {
+            window.location.href = link.href;
+        }
+    });
+
+    if (link) {
+        link.style.cssText = 'display: none !important; position: absolute; width: 0; height: 0;';
+    }
+
+    let cardBody = episode.querySelector<HTMLElement>(':scope > [data-utlp-card-body]');
+    if (!cardBody) {
+        cardBody = document.createElement('div');
+        cardBody.dataset.utlpCardBody = '1';
+        episode.appendChild(cardBody);
+    }
+
+    Object.assign(cardBody.style, {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0',
+        gap: '8px',
+        flex: '1',
+        minHeight: '60px',
+        width: '100%',
+        boxSizing: 'border-box',
+    });
+
+    if (titleEl && titleEl.parentElement !== cardBody) cardBody.appendChild(titleEl);
+    if (titleEl) {
+        Object.assign(titleEl.style, {
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: '2',
+            overflow: 'visible',
+            textOverflow: 'ellipsis',
+            lineHeight: '1.4',
+            flex: '1',
+            minWidth: '0',
+            wordBreak: 'break-word',
+            textAlign: 'left',
+            cursor: 'pointer',
+        });
+
+        titleEl.removeEventListener('click', onTitleClick);
+        titleEl.addEventListener('click', onTitleClick);
+    }
+
+    let actionsRow = episode.querySelector<HTMLElement>('[data-utlp-card-actions]');
+    if (actionsRow && actionsRow.parentElement !== cardBody) cardBody.appendChild(actionsRow);
+    if (!actionsRow) {
+        actionsRow = document.createElement('div');
+        actionsRow.dataset.utlpCardActions = '1';
+        cardBody.appendChild(actionsRow);
+    }
+
+    Object.assign(actionsRow.style, {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: '0px',
+        flexShrink: '0',
+        marginTop: '0',
+        marginLeft: 'auto',
+    });
+
+    episode.querySelectorAll<HTMLElement>('span[style*="inline-flex"]').forEach(span => {
+        if (span.parentElement !== actionsRow) actionsRow!.appendChild(span);
+    });
+}
+
+function applyListCard(episode: HTMLElement, link: HTMLAnchorElement | null, titleEl: HTMLElement | null) {
+    Object.assign(episode.style, {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderRadius: '',
+        overflow: '',
+        boxShadow: '',
+        background: '',
+        border: '',
+        cursor: '',
+        transition: '',
+        gap: '8px',
+        padding: '4px 0',
+    });
+
+    episode.removeEventListener('mouseenter', onHoverIn);
+    episode.removeEventListener('mouseleave', onHoverOut);
+
+    const thumb = episode.querySelector<HTMLElement>('[data-utlp-thumb]');
+    if (thumb) thumb.style.display = 'none';
+
+    if (link) link.style.cssText = '';
+
+    const cardBody = episode.querySelector<HTMLElement>('[data-utlp-card-body]');
+    if (cardBody) {
+        while (cardBody.firstChild) episode.appendChild(cardBody.firstChild);
+        cardBody.remove();
+    }
+
+    if (titleEl) {
+        Object.assign(titleEl.style, {
+            display: 'block',
+            flex: '1',
+            fontSize: '',
+            fontWeight: '',
+            fontFamily: '',
+            color: '',
+            lineHeight: '',
+            overflow: '',
+            textOverflow: '',
+            WebkitLineClamp: '',
+            WebkitBoxOrient: '',
+            wordBreak: '',
+            textAlign: 'left',
+            minWidth: '0',
+        });
+    }
+
+    let actionsRow = episode.querySelector<HTMLElement>('[data-utlp-card-actions]');
+    if (!actionsRow) {
+        actionsRow = document.createElement('div');
+        actionsRow.dataset.utlpCardActions = '1';
+        episode.appendChild(actionsRow);
+    }
+    Object.assign(actionsRow.style, {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: '0px',
+        flexShrink: '0',
+        marginLeft: 'auto',
+    });
+
+    episode.querySelectorAll<HTMLElement>('span[style*="inline-flex"]').forEach(span => {
+        if (span.parentElement !== actionsRow) actionsRow!.appendChild(span);
+    });
+}
+
+function buildThumbnail(): HTMLElement {
+    const thumb = document.createElement('div');
+    thumb.dataset.utlpThumb = '1';
+    Object.assign(thumb.style, {
+        width: '100%',
+        aspectRatio: '16 / 9',
+        background: '#d1d5db',
+        flexShrink: '0',
+        position: 'relative',
+        borderRadius: '6px',
+        boxShadow: '0 1px 4px rgba(0,0,0,0.10)',
+        overflow: 'hidden',
+    });
+
+    return thumb;
+}
+
+function onHoverIn(this: HTMLElement) {
+    const thumb = this.querySelector<HTMLElement>('[data-utlp-thumb]');
+    if (thumb) thumb.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
+    this.style.zIndex = '20';
+}
+
+function onHoverOut(this: HTMLElement) {
+    const thumb = this.querySelector<HTMLElement>('[data-utlp-thumb]');
+    if (thumb) thumb.style.boxShadow = '0 1px 4px rgba(0,0,0,0.10)';
+    this.style.zIndex = '';
+}
+
+function onTitleClick(this: HTMLElement, e: MouseEvent) {
+    e.stopPropagation();
+    const episode = this.closest<HTMLElement>('div.episode');
+    const link = episode?.querySelector<HTMLAnchorElement>('a');
+    if (link?.href) {
+        window.location.href = link.href;
+    }
+}

--- a/src/entrypoints/episodeList.content/gridView.ts
+++ b/src/entrypoints/episodeList.content/gridView.ts
@@ -1,85 +1,76 @@
 export const VIEW_MODE_KEY = 'utlp-view-mode';
 
-let originalColumns: HTMLElement[] = [];
+let listResizeObservers: ResizeObserver[] = [];
 
-/**
- * Gets the current view mode from localStorage
- *
- * @returns {'list' | 'grid'} The current view mode, defaulting to 'list'
- */
-export function getCurrentMode(): 'list' | 'grid' {
-    return (localStorage.getItem(VIEW_MODE_KEY) ?? 'list') as 'list' | 'grid';
+const episodeColumns = new WeakMap<HTMLElement, HTMLElement>();
+
+function getListColumnCount(containerWidth: number, minColWidth = 450, maxCols = 10): number {
+    return Math.min(Math.max(1, Math.floor(containerWidth / minColWidth)), maxCols);
 }
 
-/**
- * Records the original column wrappers that contain episode elements,so the page's original layout can be restored when switching modes.
- */
-export function saveOriginalPositions(): void {
-    const episodes = [...document.querySelectorAll<HTMLElement>('div.episode')];
+function buildThumbnail(): HTMLElement {
+    const thumb = document.createElement('div');
+    thumb.dataset.utlpThumb = '1';
+    Object.assign(thumb.style, {
+        width: '100%',
+        aspectRatio: '16 / 9',
+        background: '#d1d5db',
+        flexShrink: '0',
+        position: 'relative',
+        borderRadius: '6px',
+        boxShadow: '0 1px 4px rgba(0,0,0,0.10)',
+        overflow: 'hidden',
+    });
 
-    originalColumns = [...new Set(episodes.map(ep => ep.parentElement).filter(Boolean))] as HTMLElement[];
+    return thumb;
 }
 
-/**
- * Applies the specified view mode to the episode cards.
- *
- * @param {'list' | 'grid'} mode - The view mode to apply, either 'list' or 'grid'.
- */
-export function applyViewMode(mode: 'list' | 'grid'): void {
-    const currentMode = document.body.dataset.utlpViewMode;
-    if (currentMode === mode) return;
-    document.body.dataset.utlpViewMode = mode;
+function onHoverIn(this: HTMLElement) {
+    const thumb = this.querySelector<HTMLElement>('[data-utlp-thumb]');
+    if (thumb) thumb.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
+    this.style.zIndex = '20';
+}
 
-    const episodes = [...document.querySelectorAll<HTMLElement>('div.episode')];
-    const container = originalColumns[0]?.parentElement as HTMLElement | null;
-    if (!container) return;
+function onHoverOut(this: HTMLElement) {
+    const thumb = this.querySelector<HTMLElement>('[data-utlp-thumb]');
+    if (thumb) thumb.style.boxShadow = '0 1px 4px rgba(0,0,0,0.10)';
+    this.style.zIndex = '';
+}
 
-    if (mode === 'grid') {
-        episodes.forEach(ep => container.appendChild(ep));
-        originalColumns.forEach(col => {
-            col.style.display = 'none';
-        });
+function onTitleClick(this: HTMLElement, e: MouseEvent) {
+    e.stopPropagation();
+    const episode = this.closest<HTMLElement>('div.episode');
+    const link = episode?.querySelector<HTMLAnchorElement>('a');
+    if (link?.href) {
+        window.open(link.href, link.target || '_blank');
+    }
+}
 
-        Object.assign(container.style, {
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
-            gap: '16px',
-            padding: '4px 0',
-            alignItems: 'start',
-        });
-    } else {
-        episodes.forEach(ep => container.appendChild(ep));
-
-        originalColumns.forEach(col => {
-            col.style.display = 'contents';
-        });
-
-        Object.assign(container.style, {
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(450px, 1fr))',
-            gap: '4px 16px',
-        });
+function ensureActionsRow(episode: HTMLElement, parent: HTMLElement): HTMLElement {
+    let actionsRow = episode.querySelector<HTMLElement>('[data-utlp-card-actions]');
+    if (!actionsRow) {
+        actionsRow = document.createElement('div');
+        actionsRow.dataset.utlpCardActions = '1';
+        parent.appendChild(actionsRow);
+    } else if (actionsRow.parentElement !== parent) {
+        parent.appendChild(actionsRow);
     }
 
-    episodes.forEach(ep => styleEpisodeCard(ep, mode));
-}
+    Object.assign(actionsRow.style, {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: '0px',
+        flexShrink: '0',
+        marginLeft: 'auto',
+        marginTop: '0',
+    });
 
-/**
- * Styles a single episode element according to the given view mode
- *
- * @param episode - The episode element to style.
- * @param {'list' | 'grid'} mode - The view mode to style the episode for.
- */
-export function styleEpisodeCard(episode: HTMLElement, mode: 'list' | 'grid'): void {
-    episode.dataset.utlpViewMode = mode;
-    const link = episode.querySelector<HTMLAnchorElement>('a');
-    const titleEl = episode.querySelector<HTMLElement>('span.episode_title');
+    episode.querySelectorAll<HTMLElement>('span[style*="inline-flex"]').forEach(span => {
+        if (span.parentElement !== actionsRow) actionsRow!.appendChild(span);
+    });
 
-    if (mode === 'grid') {
-        applyGridCard(episode, link, titleEl);
-    } else {
-        applyListCard(episode, link, titleEl);
-    }
+    return actionsRow;
 }
 
 function applyGridCard(episode: HTMLElement, link: HTMLAnchorElement | null, titleEl: HTMLElement | null) {
@@ -114,15 +105,16 @@ function applyGridCard(episode: HTMLElement, link: HTMLAnchorElement | null, tit
 
     thumb.addEventListener('click', e => {
         e.stopPropagation();
-
+        e.preventDefault();
         const link = episode.querySelector<HTMLAnchorElement>('a');
         if (link?.href) {
-            window.location.href = link.href;
+            window.open(link.href, link.target || '_blank');
         }
     });
 
     if (link) {
-        link.style.cssText = 'display: none !important; position: absolute; width: 0; height: 0;';
+        link.style.cssText =
+            'display: none; position: absolute; width: 0; height: 0; overflow: hidden; pointer-events: none;';
     }
 
     let cardBody = episode.querySelector<HTMLElement>(':scope > [data-utlp-card-body]');
@@ -165,27 +157,7 @@ function applyGridCard(episode: HTMLElement, link: HTMLAnchorElement | null, tit
         titleEl.addEventListener('click', onTitleClick);
     }
 
-    let actionsRow = episode.querySelector<HTMLElement>('[data-utlp-card-actions]');
-    if (actionsRow && actionsRow.parentElement !== cardBody) cardBody.appendChild(actionsRow);
-    if (!actionsRow) {
-        actionsRow = document.createElement('div');
-        actionsRow.dataset.utlpCardActions = '1';
-        cardBody.appendChild(actionsRow);
-    }
-
-    Object.assign(actionsRow.style, {
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: '0px',
-        flexShrink: '0',
-        marginTop: '0',
-        marginLeft: 'auto',
-    });
-
-    episode.querySelectorAll<HTMLElement>('span[style*="inline-flex"]').forEach(span => {
-        if (span.parentElement !== actionsRow) actionsRow!.appendChild(span);
-    });
+    ensureActionsRow(episode, cardBody);
 }
 
 function applyListCard(episode: HTMLElement, link: HTMLAnchorElement | null, titleEl: HTMLElement | null) {
@@ -237,60 +209,171 @@ function applyListCard(episode: HTMLElement, link: HTMLAnchorElement | null, tit
         });
     }
 
-    let actionsRow = episode.querySelector<HTMLElement>('[data-utlp-card-actions]');
-    if (!actionsRow) {
-        actionsRow = document.createElement('div');
-        actionsRow.dataset.utlpCardActions = '1';
-        episode.appendChild(actionsRow);
+    ensureActionsRow(episode, episode);
+}
+
+/**
+ * Styles a single episode element according to the given view mode
+ *
+ * @param {HTMLElement}episode - The episode element to style.
+ * @param {'list' | 'grid'} mode - The view mode to style the episode for.
+ */
+export function styleEpisodeCard(episode: HTMLElement, mode: 'list' | 'grid'): void {
+    episode.dataset.utlpViewMode = mode;
+    const link = episode.querySelector<HTMLAnchorElement>('a');
+    const titleEl = episode.querySelector<HTMLElement>('span.episode_title');
+
+    if (mode === 'grid') {
+        applyGridCard(episode, link, titleEl);
+    } else {
+        applyListCard(episode, link, titleEl);
     }
-    Object.assign(actionsRow.style, {
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: '0px',
-        flexShrink: '0',
-        marginLeft: 'auto',
+}
+
+function redistributeListEpisodes(container: HTMLElement, episodes: HTMLElement[]): void {
+    const numCols = getListColumnCount(container.offsetWidth);
+    const rowsPerCol = Math.ceil(episodes.length / numCols);
+
+    container.querySelectorAll<HTMLElement>('[data-utlp-list-col]').forEach(c => c.remove());
+
+    const cols: HTMLElement[] = Array.from({ length: numCols }, () => {
+        const col = document.createElement('div');
+        col.dataset.utlpListCol = '1';
+        Object.assign(col.style, {
+            display: 'flex',
+            flexDirection: 'column',
+            flex: '1',
+            minWidth: '0',
+            boxSizing: 'border-box',
+        });
+        container.appendChild(col);
+        return col;
     });
 
-    episode.querySelectorAll<HTMLElement>('span[style*="inline-flex"]').forEach(span => {
-        if (span.parentElement !== actionsRow) actionsRow!.appendChild(span);
+    episodes.forEach((ep, i) => {
+        const colIndex = Math.floor(i / rowsPerCol);
+        const targetCol = cols[colIndex] ?? cols[cols.length - 1];
+        targetCol.appendChild(ep);
+        styleEpisodeCard(ep, 'list');
     });
 }
 
-function buildThumbnail(): HTMLElement {
-    const thumb = document.createElement('div');
-    thumb.dataset.utlpThumb = '1';
-    Object.assign(thumb.style, {
-        width: '100%',
-        aspectRatio: '16 / 9',
-        background: '#d1d5db',
-        flexShrink: '0',
-        position: 'relative',
-        borderRadius: '6px',
-        boxShadow: '0 1px 4px rgba(0,0,0,0.10)',
-        overflow: 'hidden',
+function disconnectListObservers(): void {
+    listResizeObservers.forEach(o => o.disconnect());
+    listResizeObservers = [];
+}
+
+/**
+ * Saves the original parent column of each episode to restore later
+ */
+export function saveOriginalPositions(): void {
+    const episodes = [...document.querySelectorAll<HTMLElement>('div.episode')];
+    episodes.forEach(ep => {
+        if (ep.parentElement) {
+            episodeColumns.set(ep, ep.parentElement);
+        }
     });
-
-    return thumb;
 }
 
-function onHoverIn(this: HTMLElement) {
-    const thumb = this.querySelector<HTMLElement>('[data-utlp-thumb]');
-    if (thumb) thumb.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
-    this.style.zIndex = '20';
-}
+/**
+ * Applies the specified view mode to the episode cards.
+ *
+ * @param {'list' | 'grid'} mode - The view mode to apply, either 'list' or 'grid'.
+ */
+export function applyViewMode(mode: 'list' | 'grid'): void {
+    const currentMode = document.body.dataset.utlpViewMode;
+    if (currentMode === mode) return;
+    document.body.dataset.utlpViewMode = mode;
 
-function onHoverOut(this: HTMLElement) {
-    const thumb = this.querySelector<HTMLElement>('[data-utlp-thumb]');
-    if (thumb) thumb.style.boxShadow = '0 1px 4px rgba(0,0,0,0.10)';
-    this.style.zIndex = '';
-}
+    const episodes = [...document.querySelectorAll<HTMLElement>('div.episode')];
+    const originalColumns = [...new Set(episodes.map(ep => episodeColumns.get(ep)).filter(Boolean))] as HTMLElement[];
+    const containers = [...new Set(originalColumns.map(col => col.parentElement).filter(Boolean))] as HTMLElement[];
+    if (!containers.length) return;
 
-function onTitleClick(this: HTMLElement, e: MouseEvent) {
-    e.stopPropagation();
-    const episode = this.closest<HTMLElement>('div.episode');
-    const link = episode?.querySelector<HTMLAnchorElement>('a');
-    if (link?.href) {
-        window.location.href = link.href;
+    if (mode === 'grid') {
+        disconnectListObservers();
+
+        episodes.forEach(ep => {
+            const originalCol = episodeColumns.get(ep);
+            if (originalCol) originalCol.appendChild(ep);
+        });
+        originalColumns.forEach(col => {
+            col.style.display = 'none';
+        });
+
+        containers.forEach(container => {
+            container.querySelectorAll('[data-utlp-list-col]').forEach(c => c.remove());
+            container.classList.remove('grid', 'grid-cols-1', 'md:grid-cols-3');
+            Object.assign(container.style, {
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+                gap: '16px',
+                width: '100%',
+                maxWidth: 'none',
+                boxSizing: 'border-box',
+            });
+        });
+
+        originalColumns.forEach(col => {
+            col.style.cssText = '';
+            const hasEpisodes = [...col.children].some(child => (child as HTMLElement).classList.contains('episode'));
+            if (!hasEpisodes) {
+                col.style.display = 'none';
+                return;
+            }
+            Object.assign(col.style, {
+                display: 'contents',
+                gridTemplateColumns: '',
+                gap: '',
+            });
+        });
+
+        episodes.forEach(ep => styleEpisodeCard(ep, 'grid'));
+    } else {
+        disconnectListObservers();
+
+        originalColumns.forEach(col => {
+            col.style.display = 'none';
+        });
+
+        containers.forEach(container => {
+            container.classList.remove('grid', 'grid-cols-1', 'md:grid-cols-3');
+            Object.assign(container.style, {
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'flex-start',
+                flexWrap: 'nowrap',
+                gap: '16px',
+                width: '100%',
+                maxWidth: 'none',
+                boxSizing: 'border-box',
+            });
+
+            const containerEpisodes = episodes.filter(ep => {
+                const originalCol = episodeColumns.get(ep);
+                return (
+                    originalCol?.closest('[data-utlp-container]') === container ||
+                    originalCol?.parentElement === container
+                );
+            });
+
+            redistributeListEpisodes(container, containerEpisodes);
+
+            const observer = new ResizeObserver(() => {
+                redistributeListEpisodes(container, containerEpisodes);
+            });
+
+            observer.observe(container);
+            listResizeObservers.push(observer);
+        });
     }
+}
+
+/**
+ * Gets the current view mode from localStorage
+ *
+ * @returns {'list' | 'grid'} The current view mode, defaulting to 'list'
+ */
+export function getCurrentMode(): 'list' | 'grid' {
+    return (localStorage.getItem(VIEW_MODE_KEY) ?? 'list') as 'list' | 'grid';
 }

--- a/src/entrypoints/episodeList.content/index.ts
+++ b/src/entrypoints/episodeList.content/index.ts
@@ -1,5 +1,7 @@
 import { browser, defineContentScript } from '#imports';
 import { formatLectureTitle } from './utils';
+import { getCurrentMode, applyViewMode, styleEpisodeCard, saveOriginalPositions } from './gridView';
+import { buildViewToggle } from './viewToggle';
 
 const COLORS = {
     burntorange: '#bf5700',
@@ -163,5 +165,34 @@ export default defineContentScript({
         if (faq_link) faq_link.style.fontFamily = 'Roboto Flex';
 
         formatEpisodeTitles();
+
+        if (!document.getElementById('utlp-view-toolbar')) {
+            const h2 = document.querySelector<HTMLElement>('h2');
+            if (h2) {
+                h2.insertAdjacentElement('afterend', buildViewToggle());
+            }
+        }
+
+        saveOriginalPositions();
+        applyViewMode(getCurrentMode());
+
+        const observer = new MutationObserver(() => {
+            const mode = getCurrentMode();
+
+            document.querySelectorAll<HTMLElement>('div.episode').forEach(ep => {
+                if (ep.dataset.utlpViewMode !== mode) {
+                    styleEpisodeCard(ep, mode);
+                }
+
+                const actionsRow = ep.querySelector<HTMLElement>('[data-utlp-card-actions]');
+                if (actionsRow) {
+                    ep.querySelectorAll<HTMLElement>('span[style*="inline-flex"]').forEach(span => {
+                        if (span.parentElement !== actionsRow) actionsRow.appendChild(span);
+                    });
+                }
+            });
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
     },
 });

--- a/src/entrypoints/episodeList.content/viewToggle.ts
+++ b/src/entrypoints/episodeList.content/viewToggle.ts
@@ -1,0 +1,92 @@
+import { VIEW_MODE_KEY, getCurrentMode, applyViewMode } from './gridView';
+
+const COLORS = {
+    burntorange: '#bf5700',
+    white: '#FFFFFF',
+};
+
+/**
+ * Builds the list/grid view toggle toolbar
+ *
+ * Renders two icon buttons (list and grid) reflecting the currently saved
+ *
+ * @returns The toolbar element containing the view toggle buttons
+ */
+export function buildViewToggle(): HTMLElement {
+    const savedMode = getCurrentMode();
+
+    const toolbar = document.createElement('div');
+    toolbar.id = 'utlp-view-toolbar';
+    Object.assign(toolbar.style, {
+        display: 'flex',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+        gap: '6px',
+        marginBottom: '16px',
+        marginTop: '12px',
+    });
+
+    const makeBtn = (mode: 'list' | 'grid', iconClass: string, label: string): HTMLButtonElement => {
+        const btn = document.createElement('button');
+        btn.dataset.utlpViewMode = mode;
+        btn.title = label;
+        btn.setAttribute('aria-label', label);
+
+        const i = document.createElement('i');
+        i.className = `ph ${iconClass}`;
+        btn.appendChild(i);
+
+        const applyActive = (isActive: boolean) => {
+            Object.assign(btn.style, {
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '36px',
+                height: '36px',
+                borderRadius: '6px',
+                border: '1.5px solid',
+                cursor: 'pointer',
+                transition: 'background 0.15s, color 0.15s',
+                fontSize: '18px',
+                borderColor: isActive ? COLORS.burntorange : '#d1d5db',
+                background: isActive ? COLORS.burntorange : COLORS.white,
+                color: isActive ? COLORS.white : '#6b7280',
+            });
+        };
+
+        applyActive(mode === savedMode);
+
+        btn.addEventListener('mouseenter', () => {
+            if (btn.dataset.utlpViewMode !== getCurrentMode()) {
+                btn.style.background = '#f3f4f6';
+                btn.style.color = '#374151';
+            }
+        });
+
+        btn.addEventListener('mouseleave', () => {
+            applyActive(btn.dataset.utlpViewMode === getCurrentMode());
+        });
+
+        btn.addEventListener('click', () => {
+            localStorage.setItem(VIEW_MODE_KEY, mode);
+
+            toolbar.querySelectorAll<HTMLButtonElement>('[data-utlp-view-mode]').forEach(b => {
+                const isActive = b.dataset.utlpViewMode === mode;
+                Object.assign(b.style, {
+                    borderColor: isActive ? COLORS.burntorange : '#d1d5db',
+                    background: isActive ? COLORS.burntorange : COLORS.white,
+                    color: isActive ? COLORS.white : '#6b7280',
+                });
+            });
+
+            applyViewMode(mode);
+        });
+
+        return btn;
+    };
+
+    toolbar.appendChild(makeBtn('list', 'ph-list', 'List view'));
+    toolbar.appendChild(makeBtn('grid', 'ph-grid-four', 'Grid view'));
+
+    return toolbar;
+}


### PR DESCRIPTION
Addresses #38  

- Adds a list/grid view toggle for the lecture episode list, letting users switch between the original list layout and a new card-based grid layout
- Grid view displays each episode as a card with a thumbnail (gray default image), video title, and bookmark and edit-title buttons as specified in issue https://linear.app/longhorn-devs/issue/UTLP-27/barebones-right-side-view-preliminary 

<img width="587" height="239" alt="Screenshot 2026-06-20 142515" src="https://github.com/user-attachments/assets/44e1408d-18d4-403a-aa2f-be179eafec54" />
